### PR TITLE
feat: add min_distance to better the answer

### DIFF
--- a/app/src/configs/config.rs
+++ b/app/src/configs/config.rs
@@ -141,6 +141,9 @@ pub struct QueryConfig {
     #[clap(long = "top", default_value_t = 2)]
     pub top: usize,
 
+    #[clap(long = "min_distance", default_value_t)]
+    pub min_distance: String,
+
     #[clap(long = "prompt", default_value_t)]
     pub prompt: String,
 }
@@ -151,6 +154,7 @@ impl Default for QueryConfig {
             min_content_length: 50,
             max_content_length: 8000,
             top: 2,
+            min_distance: "".to_string(),
             prompt: "".to_string(),
         }
     }


### PR DESCRIPTION
## Summary

`min_distance`: if the similar distance big than it, the snippts will sikpped, default is `0.28`.
Clap can not support float, so use string here.

```
min_distance = "0.25"
```

or:
```
--min_distance 2.1
```